### PR TITLE
Fixing log file logger name

### DIFF
--- a/pagecache/cli.py
+++ b/pagecache/cli.py
@@ -50,9 +50,9 @@ def parseargs():
     parser.add_argument(
         "--log-level",
         type=str,
-        choices=["INFO", "WARNING", "DEBUG"],
+        choices=["INFO", "DEBUG"],
         default="INFO",
-        help="Sets the debug level",
+        help="Sets the log level",
         required=False,
     )
     parser.add_argument(
@@ -67,7 +67,6 @@ def parseargs():
 
 def load_daemon_mode(args, log_file, log_file_fd):
     context = daemon.DaemonContext(
-        working_directory="/opt/pagecache_ttl",
         umask=0o002,
         pidfile=PidFile(pidname=log_file),
     )
@@ -78,6 +77,7 @@ def load_daemon_mode(args, log_file, log_file_fd):
             args.tmp_dir,
             args.interval_seconds,
             args.max_time_window_seconds,
+            args.log_file,
             args.send_metrics_to_dogstatsd,
         )
         pagecache_monitor.run()
@@ -88,6 +88,7 @@ def load_script_mode(args):
         args.tmp_dir,
         args.interval_seconds,
         args.max_time_window_seconds,
+        args.log_file,
         args.send_metrics_to_dogstatsd,
     )
     pagecache_monitor.run()

--- a/pagecache/configure_logging.py
+++ b/pagecache/configure_logging.py
@@ -2,11 +2,12 @@ import logging
 
 
 def configure_logging(log_level, log_file):
-    log_level = logging.INFO
     if log_level == "DEBUG":
         log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
 
-    logger = logging.getLogger("pagecache_ttl")
+    logger = logging.getLogger("pagecache")
     logger.setLevel(log_level)
     formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
 

--- a/pagecache/pagecache_monitor.py
+++ b/pagecache/pagecache_monitor.py
@@ -34,7 +34,7 @@ class PageCacheMonitor(object):
         if send_metrics_to_dogstatsd:
             self.dogstatsd_options = {"statsd_host": "127.0.0.1", "statsd_port": 8125}
             initialize(**self.dogstatsd_options)
-            self.dogstatsd_prefix = "pagecache_ttl.min_cached_time_seconds"
+            self.dogstatsd_metric_name = "pagecache_ttl.min_cached_time_seconds"
             self.statsd = statsd
 
     def _create_new_file(self):
@@ -189,10 +189,10 @@ class PageCacheMonitor(object):
         """
         Sends metrics to DogStatsD (localhost)
         """
-        self.statsd.gauge(self.dogstatsd_prefix, min_cached_time)
+        self.statsd.gauge(self.dogstatsd_metric_name, min_cached_time)
         logger.debug(
             "Delivered metric to DogStatsD: {}:{}".format(
-                self.dogstatsd_prefix, min_cached_time
+                self.dogstatsd_metric_name, min_cached_time
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __location__ = os.path.join(
     os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe()))
 )
 
-version = "1.1.1"
+version = "1.1.2"
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()

--- a/tests/units/test_pagecache_monitor.py
+++ b/tests/units/test_pagecache_monitor.py
@@ -229,7 +229,7 @@ def test_deliver_metrics_to_dogstatsd():
         pcm._deliver_metrics_to_dogstatsd(min_cached_time)
 
     # Check the method was called with the proper argument of min_cached_time
-    mock_statsd_gauge.assert_called_once_with(pcm.dogstatsd_prefix, min_cached_time)
+    mock_statsd_gauge.assert_called_once_with(pcm.dogstatsd_metric_name, min_cached_time)
 
 
 def test_report_metric():


### PR DESCRIPTION
### Summary

* Removing daemon workdir directory as logs must be written in /var/log
* Fixing logger name 
* Removing WARNING mode in logger as it is not used
* Add missing parameter log-file  in PageCacheMonitor when object is instanced 