### PR TITLE
Adding signal handlers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __location__ = os.path.join(
     os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe()))
 )
 
-version = "1.1.2"
+version = "1.1.3"
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()

--- a/tests/units/test_pagecache_monitor.py
+++ b/tests/units/test_pagecache_monitor.py
@@ -229,7 +229,9 @@ def test_deliver_metrics_to_dogstatsd():
         pcm._deliver_metrics_to_dogstatsd(min_cached_time)
 
     # Check the method was called with the proper argument of min_cached_time
-    mock_statsd_gauge.assert_called_once_with(pcm.dogstatsd_metric_name, min_cached_time)
+    mock_statsd_gauge.assert_called_once_with(
+        pcm.dogstatsd_metric_name, min_cached_time
+    )
 
 
 def test_report_metric():


### PR DESCRIPTION
### summary

* This PR add the signal handlers for both executions  modes, `script` and `daemon` 
the main goal of this is to log properly when the process is terminated

* Adding the proper PID file for the daemon in `/var/run`
